### PR TITLE
Add DuckDB sanity check script

### DIFF
--- a/sanity-checks/sc1.py
+++ b/sanity-checks/sc1.py
@@ -1,0 +1,5 @@
+import duckdb
+con = duckdb.connect("duckdb/fit.db", read_only=True)
+print("Tables:", [r[0] for r in con.execute("SHOW TABLES").fetchall()])
+print("Feature order:", con.execute("SELECT * FROM feature_order ORDER BY ord").fetchall())
+con.close()


### PR DESCRIPTION
## Summary
- add `sanity-checks/sc1.py` to inspect DuckDB database tables and feature order

## Testing
- `pytest -q` *(no tests found)*
- `python sanity-checks/sc1.py` *(fails: No module named 'duckdb')*


------
https://chatgpt.com/codex/tasks/task_e_68c786d93fa083309963b1ae8e880476